### PR TITLE
extract `errVerbose` from error to another field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pingcap/log
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8
+	github.com/pingcap/errors v0.11.0
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	go.uber.org/atomic v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8 h1:USx2/E1bX46VG32FIw034Au6seQ2fY9NEILmNh/UlQg=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
+github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/zap_log_test.go
+++ b/zap_log_test.go
@@ -254,11 +254,7 @@ func (t *testZapLogSuite) TestRotateLog(c *C) {
 func (t *testZapLogSuite) TestErrorLog(c *C) {
 	conf := &Config{Level: "debug", File: FileLogConfig{}, DisableTimestamp: true}
 	lg := newZapTestLogger(conf, c)
-	lg.Error("", zap.NamedError("err", mockStackMethod()))
+	lg.Error("", zap.NamedError("err", errors.New("log-stack-test")))
 	lg.AssertContains("[err=log-stack-test]")
 	lg.AssertContains("] [errVerbose=\"")
-}
-
-func mockStackMethod() error {
-	return errors.New("log-stack-test")
 }

--- a/zap_text_encoder.go
+++ b/zap_text_encoder.go
@@ -36,6 +36,7 @@ package log
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"math"
 	"strings"
 	"sync"
@@ -600,9 +601,31 @@ func (enc *textEncoder) tryAddRuneError(r rune, size int) bool {
 }
 
 func (enc *textEncoder) addFields(fields []zapcore.Field) {
-	for i := range fields {
+	for _, f := range fields {
+		if f.Type == zapcore.ErrorType {
+			enc.encodeError(f)
+			continue
+		}
 		enc.beginQuoteFiled()
-		fields[i].AddTo(enc)
+		f.AddTo(enc)
 		enc.endQuoteFiled()
+	}
+}
+
+func (enc *textEncoder) encodeError(f zapcore.Field) {
+	err := f.Interface.(error)
+	basic := err.Error()
+	enc.beginQuoteFiled()
+	enc.AddString(f.Key, basic)
+	enc.endQuoteFiled()
+	if e, isFormatter := err.(fmt.Formatter); isFormatter {
+		verbose := fmt.Sprintf("%+v", e)
+		if verbose != basic {
+			// This is a rich error type, like those produced by
+			// github.com/pkg/errors.
+			enc.beginQuoteFiled()
+			enc.AddString(f.Key+"Verbose", verbose)
+			enc.endQuoteFiled()
+		}
 	}
 }

--- a/zap_text_encoder.go
+++ b/zap_text_encoder.go
@@ -603,6 +603,8 @@ func (enc *textEncoder) tryAddRuneError(r rune, size int) bool {
 func (enc *textEncoder) addFields(fields []zapcore.Field) {
 	for _, f := range fields {
 		if f.Type == zapcore.ErrorType {
+			// handle ErrorType in pingcap/log to fix "[key=?,keyVerbose=?]" problem.
+			// see more detail at https://github.com/pingcap/log/pull/5
 			enc.encodeError(f)
 			continue
 		}


### PR DESCRIPTION
### what we do:

```
log.Info(zap.Error(err));
```
`err` is produced by `pkg/errors` or `pingcap/errors`

### expect

```
[ERROR] [zap_log_test.go:257] [err=log-stack-test] [errVerbose=\"log-stack-test\\ngithub.com/pingcap/log.mockStackMethod\\n\\t/home/robi/Code/go/src/github.com/pingcap/log/zap_log_test.go:263\\ngithu
```

### but got

```
[ERROR] [zap_log_test.go:257] [error=log-stack-test,errorVerbose=\"log-stack-test\\ngithub.com/pingcap/log.mockStackMethod\\n\\t/home/robi/Code/go/src/github.com/pingcap/log/zap_log_test.go:263\\ngithu
```

### what changed

self take `encodeError` log in pingcap/log

ps: old logic at https://github.com/lysu/zap/blob/092e7c1e97df5a58d7f0cb77df0f5975f13b71ea/zapcore/error.go#L45

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/log/5)
<!-- Reviewable:end -->
