### PR TITLE
*: fix the stack level and error verbose

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	// default, stacktraces are captured for WarnLevel and above logs in
 	// development and ErrorLevel and above in production.
 	DisableStacktrace bool `toml:"disable-stacktrace" json:"disable-stacktrace"`
+	// DisableErrorVerbose stops annotating logs with the full verbose error
+	// message.
+	DisableErrorVerbose bool `toml:"disable-error-verbose", json:"disable-error-verbose"`
 	// SamplingConfig sets a sampling strategy for the logger. Sampling caps the
 	// global CPU and I/O load that logging puts on your process while attempting
 	// to preserve a representative subset of your logs.
@@ -74,24 +77,7 @@ type ZapProperties struct {
 }
 
 func newZapTextEncoder(cfg *Config) zapcore.Encoder {
-	cc := zapcore.EncoderConfig{
-		// Keys can be anything except the empty string.
-		TimeKey:        "time",
-		LevelKey:       "level",
-		NameKey:        "name",
-		CallerKey:      "caller",
-		MessageKey:     "message",
-		StacktraceKey:  "stack",
-		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.CapitalLevelEncoder,
-		EncodeTime:     DefaultTimeEncoder,
-		EncodeDuration: zapcore.StringDurationEncoder,
-		EncodeCaller:   ShortCallerEncoder,
-	}
-	if cfg.DisableTimestamp {
-		cc.TimeKey = ""
-	}
-	return NewTextEncoder(cc)
+	return NewTextEncoder(cfg)
 }
 
 func (cfg *Config) buildOptions(errSink zapcore.WriteSyncer) []zap.Option {

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8 h1:USx2/E1bX46VG32FIw034Au6seQ2fY9NEILmNh/UlQg=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
+github.com/pingcap/errors v0.11.0 h1:DCJQB8jrHbQ1VVlMFIrbj2ApScNNotVmkSNplu2yUt4=
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/log.go
+++ b/log.go
@@ -39,13 +39,18 @@ func InitLogger(cfg *Config, opts ...zap.Option) (*zap.Logger, *ZapProperties, e
 		}
 		output = stdOut
 	}
+	return InitLoggerWithWriteSyncer(cfg, output, opts...)
+}
+
+// InitLoggerWithWriteSyncer initializes a zap logger with specified  write syncer.
+func InitLoggerWithWriteSyncer(cfg *Config, output zapcore.WriteSyncer, opts ...zap.Option) (*zap.Logger, *ZapProperties, error) {
 	level := zap.NewAtomicLevel()
 	err := level.UnmarshalText([]byte(cfg.Level))
 	if err != nil {
 		return nil, nil, err
 	}
 	core := NewTextCore(newZapTextEncoder(cfg).(*textEncoder), output, level)
-	opts = append(opts, cfg.buildOptions(output)...)
+	opts = append(cfg.buildOptions(output), opts...)
 	lg := zap.New(core, opts...)
 	r := &ZapProperties{
 		Core:   core,

--- a/zap_text_encoder.go
+++ b/zap_text_encoder.go
@@ -124,9 +124,10 @@ func putTextEncoder(enc *textEncoder) {
 
 type textEncoder struct {
 	*zapcore.EncoderConfig
-	buf            *buffer.Buffer
-	spaced         bool // include spaces after colons and commas
-	openNamespaces int
+	buf                 *buffer.Buffer
+	spaced              bool // include spaces after colons and commas
+	openNamespaces      int
+	disableErrorVerbose bool
 
 	// for encoding generic values by reflection
 	reflectBuf *buffer.Buffer
@@ -135,11 +136,29 @@ type textEncoder struct {
 
 // NewTextEncoder creates a fast, low-allocation Text encoder. The encoder
 // appropriately escapes all field keys and values.
-func NewTextEncoder(cfg zapcore.EncoderConfig) zapcore.Encoder {
+func NewTextEncoder(cfg *Config) zapcore.Encoder {
+	cc := zapcore.EncoderConfig{
+		// Keys can be anything except the empty string.
+		TimeKey:        "time",
+		LevelKey:       "level",
+		NameKey:        "name",
+		CallerKey:      "caller",
+		MessageKey:     "message",
+		StacktraceKey:  "stack",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.CapitalLevelEncoder,
+		EncodeTime:     DefaultTimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   ShortCallerEncoder,
+	}
+	if cfg.DisableTimestamp {
+		cc.TimeKey = ""
+	}
 	return &textEncoder{
-		EncoderConfig: &cfg,
-		buf:           _pool.Get(),
-		spaced:        false,
+		EncoderConfig:       &cc,
+		buf:                 _pool.Get(),
+		spaced:              false,
+		disableErrorVerbose: cfg.DisableErrorVerbose,
 	}
 }
 
@@ -371,6 +390,7 @@ func (enc *textEncoder) cloned() *textEncoder {
 	clone.EncoderConfig = enc.EncoderConfig
 	clone.spaced = enc.spaced
 	clone.openNamespaces = enc.openNamespaces
+	clone.disableErrorVerbose = enc.disableErrorVerbose
 	clone.buf = _pool.Get()
 	return clone
 }
@@ -620,6 +640,9 @@ func (enc *textEncoder) encodeError(f zapcore.Field) {
 	enc.beginQuoteFiled()
 	enc.AddString(f.Key, basic)
 	enc.endQuoteFiled()
+	if enc.disableErrorVerbose {
+		return
+	}
 	if e, isFormatter := err.(fmt.Formatter); isFormatter {
 		verbose := fmt.Sprintf("%+v", e)
 		if verbose != basic {


### PR DESCRIPTION
- Fix `zap.AddStacktrace(zapcore.FatalLevel)` not works
- Add a `DisableErrorVerbose` to ignore the filed `errorVerbose`
Signed-off-by: nolouch <nolouch@gmail.com>