### PR TITLE
remove the LogRotate field

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,8 +28,6 @@ const (
 type FileLogConfig struct {
 	// Log filename, leave empty to disable file log.
 	Filename string `toml:"filename" json:"filename"`
-	// Is log rotate enabled.
-	LogRotate bool `toml:"log-rotate" json:"log-rotate"`
 	// Max size for a single file, in MB.
 	MaxSize int `toml:"max-size" json:"max-size"`
 	// Max log keep days, default is never deleting.

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Nobody is using it, change this config doesn't take effect.
It makes people confusing.

@nolouch 