### PR TITLE
remove calling close() if zap.Open returns error

### DIFF
--- a/log.go
+++ b/log.go
@@ -32,9 +32,8 @@ func InitLogger(cfg *Config, opts ...zap.Option) (*zap.Logger, *ZapProperties, e
 		}
 		output = zapcore.AddSync(lg)
 	} else {
-		stdOut, close, err := zap.Open([]string{"stdout"}...)
+		stdOut, _, err := zap.Open([]string{"stdout"}...)
 		if err != nil {
-			close()
 			return nil, nil, err
 		}
 		output = stdOut


### PR DESCRIPTION
if zap.Open returns error, close will be nil, close() will panic
