### PR TITLE
output the internal errors of zap logger to stderr

### DIFF
--- a/config.go
+++ b/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	// ErrorOutputPath is a path to write internal logger errors to.
 	// If this field is not set, the internal logger errors will be sent to the same file as in File field.
 	// Note: if we want to output the logger errors to stderr, we can just set this field to "stderr"
-	ErrorOutputPath string
+	ErrorOutputPath string `toml:"error-output-path" json:"error-output-path"`
 }
 
 // ZapProperties records some information about zap.

--- a/config.go
+++ b/config.go
@@ -67,8 +67,8 @@ type Config struct {
 	// Values configured here are per-second. See zapcore.NewSampler for details.
 	Sampling *zap.SamplingConfig `toml:"sampling" json:"sampling"`
 	// ErrorOutputPath is a path to write internal logger errors to.
-  // If this field is not set, the internal logger errors will be sent to the same file as in File field.
-  // Note: if we want to output the logger errors to stderr, we can just set this field to "stderr"
+	// If this field is not set, the internal logger errors will be sent to the same file as in File field.
+	// Note: if we want to output the logger errors to stderr, we can just set this field to "stderr"
 	ErrorOutputPath string
 }
 

--- a/config.go
+++ b/config.go
@@ -66,6 +66,10 @@ type Config struct {
 	//
 	// Values configured here are per-second. See zapcore.NewSampler for details.
 	Sampling *zap.SamplingConfig `toml:"sampling" json:"sampling"`
+	// ErrorOutputPath is a path to write internal logger errors to.
+  // If this field is not set, the internal logger errors will be sent to the same file as in File field.
+  // Note: if we want to output the logger errors to stderr, we can just set this field to "stderr"
+	ErrorOutputPath string
 }
 
 // ZapProperties records some information about zap.

--- a/log.go
+++ b/log.go
@@ -84,7 +84,7 @@ func InitLoggerWithWriteSyncer(cfg *Config, output zapcore.WriteSyncer, opts ...
 		return nil, nil, err
 	}
 	core := NewTextCore(encoder, output, level)
-	opts = append(cfg.buildOptions(output), opts...)
+	opts = append(cfg.buildOptions(os.Stderr), opts...)
 	lg := zap.New(core, opts...)
 	r := &ZapProperties{
 		Core:   core,

--- a/log.go
+++ b/log.go
@@ -40,6 +40,7 @@ func init() {
 // InitLogger initializes a zap logger.
 func InitLogger(cfg *Config, opts ...zap.Option) (*zap.Logger, *ZapProperties, error) {
 	var output zapcore.WriteSyncer
+	var errOutput zapcore.WriteSyncer
 	if len(cfg.File.Filename) > 0 {
 		lg, err := initFileLog(&cfg.File)
 		if err != nil {
@@ -53,7 +54,17 @@ func InitLogger(cfg *Config, opts ...zap.Option) (*zap.Logger, *ZapProperties, e
 		}
 		output = stdOut
 	}
-	return InitLoggerWithWriteSyncer(cfg, output, opts...)
+	if len(cfg.ErrorOutputPath) > 0 {
+		errOut, _, err := zap.Open([]string{cfg.ErrorOutputPath}...)
+		if err != nil {
+			return nil, nil, err
+		}
+		errOutput = errOut
+	} else {
+		errOutput = output
+	}
+
+	return InitLoggerWithWriteSyncer(cfg, output, errOutput, opts...)
 }
 
 func InitTestLogger(t zaptest.TestingT, cfg *Config, opts ...zap.Option) (*zap.Logger, *ZapProperties, error) {
@@ -64,11 +75,11 @@ func InitTestLogger(t zaptest.TestingT, cfg *Config, opts ...zap.Option) (*zap.L
 		zap.ErrorOutput(writer.WithMarkFailed(true)),
 	}
 	opts = append(zapOptions, opts...)
-	return InitLoggerWithWriteSyncer(cfg, writer, opts...)
+	return InitLoggerWithWriteSyncer(cfg, writer, writer, opts...)
 }
 
 // InitLoggerWithWriteSyncer initializes a zap logger with specified write syncer.
-func InitLoggerWithWriteSyncer(cfg *Config, output zapcore.WriteSyncer, opts ...zap.Option) (*zap.Logger, *ZapProperties, error) {
+func InitLoggerWithWriteSyncer(cfg *Config, output, errOutput zapcore.WriteSyncer, opts ...zap.Option) (*zap.Logger, *ZapProperties, error) {
 	level := zap.NewAtomicLevel()
 	err := level.UnmarshalText([]byte(cfg.Level))
 	if err != nil {
@@ -84,7 +95,7 @@ func InitLoggerWithWriteSyncer(cfg *Config, output zapcore.WriteSyncer, opts ...
 		return nil, nil, err
 	}
 	core := NewTextCore(encoder, output, level)
-	opts = append(cfg.buildOptions(os.Stderr), opts...)
+	opts = append(cfg.buildOptions(errOutput), opts...)
 	lg := zap.New(core, opts...)
 	r := &ZapProperties{
 		Core:   core,


### PR DESCRIPTION
Solve the problem in [cdc issue 3362](https://github.com/pingcap/ticdc/issues/3362#) .

At present, when we write log messages to a log file which resides in a full disk, pingcap/log just silently discard the i/o error "no space left on device". As a result, users can not conveniently identify the root cause.

Similarly, when other internal errors happen in zap logger, we should output them to stderr as soon as possible.