### PR TITLE
Remove invalid comments

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,7 +41,7 @@ type FileLogConfig struct {
 type Config struct {
 	// Log level.
 	Level string `toml:"level" json:"level"`
-	// Log format. one of json or text.
+	// Log format. One of json or text.
 	Format string `toml:"format" json:"format"`
 	// Disable automatic timestamps in output.
 	DisableTimestamp bool `toml:"disable-timestamp" json:"disable-timestamp"`

--- a/config.go
+++ b/config.go
@@ -41,7 +41,7 @@ type FileLogConfig struct {
 type Config struct {
 	// Log level.
 	Level string `toml:"level" json:"level"`
-	// Log format. one of json, text, or console.
+	// Log format. one of json or text.
 	Format string `toml:"format" json:"format"`
 	// Disable automatic timestamps in output.
 	DisableTimestamp bool `toml:"disable-timestamp" json:"disable-timestamp"`


### PR DESCRIPTION
According to https://github.com/pingcap/log/blob/master/zap_text_encoder.go#L158, the valid log formats are `text` and `json`. `console` log format will panic when initializing logger.

`console` in comments should be removed.