### PR TITLE
return error if init file failed

### DIFF
--- a/log.go
+++ b/log.go
@@ -178,7 +178,10 @@ func initFileLog(cfg *FileLogConfig) (*lumberjack.Logger, error) {
 		if st.IsDir() {
 			return nil, errors.New("can't use directory as log file name")
 		}
+	} else if !os.IsNotExist(err) {
+		return nil, err
 	}
+
 	if cfg.MaxSize == 0 {
 		cfg.MaxSize = defaultLogMaxSize
 	}

--- a/zap_log_test.go
+++ b/zap_log_test.go
@@ -287,6 +287,26 @@ func TestCompressError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestLogFileNoPermission(t *testing.T) {
+	tempDir, _ := os.MkdirTemp("/tmp", "tests-log")
+	defer os.RemoveAll(tempDir)
+	conf := &Config{
+		Level: "info",
+		File: FileLogConfig{
+			Filename: tempDir + "/test.log",
+			MaxSize:  1,
+		},
+	}
+	_, _, err := InitLogger(conf)
+	require.NoError(t, err)
+
+	err = os.Chmod(tempDir, 0)
+	require.NoError(t, err)
+
+	_, _, err = InitLogger(conf)
+	require.Contains(t, err.Error(), "permission denied")
+}
+
 // testLogSpy is a testing.TB that captures logged messages.
 type testLogSpy struct {
 	testing.TB


### PR DESCRIPTION
When initializing the logger, we should return an error if we don't have permissions on the log file.